### PR TITLE
Prevent duplicate auto-whispers

### DIFF
--- a/app-core/src/main/java/com/mercury/platform/shared/HistoryManager.java
+++ b/app-core/src/main/java/com/mercury/platform/shared/HistoryManager.java
@@ -103,6 +103,19 @@ public class HistoryManager {
         return chunk;
     }
 
+    public boolean matchesRecent(String message, int messagesCount) {
+        int index = 0;
+        if (messages.length >= messagesCount) {
+            index = messages.length - 1 - messagesCount;
+        }
+        for (; index < messages.length - 1; index++) {
+            if (message.equals(messages[index])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static class HistoryManagerHolder {
         static final HistoryManager HOLDER_INSTANCE = new HistoryManager();
     }

--- a/app-core/src/main/java/com/mercury/platform/shared/hotkey/ClipboardListener.java
+++ b/app-core/src/main/java/com/mercury/platform/shared/hotkey/ClipboardListener.java
@@ -1,5 +1,6 @@
 package com.mercury.platform.shared.hotkey;
 
+import com.mercury.platform.shared.HistoryManager;
 import com.mercury.platform.shared.config.Configuration;
 import com.mercury.platform.shared.config.descriptor.NotificationSettingsDescriptor;
 import com.mercury.platform.shared.store.MercuryStoreCore;
@@ -35,7 +36,9 @@ public class ClipboardListener {
                                  message.toLowerCase().contains("i'd like") ||
                                  (message.toLowerCase().contains("wtb") && message.toLowerCase().contains("(stash")))) {
 
-                                MercuryStoreCore.chatClipboardSubject.onNext(true);
+                                if (!HistoryManager.INSTANCE.matchesRecent(message, 5)) {
+                                    MercuryStoreCore.chatClipboardSubject.onNext(true);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This change addresses one major problem:
- User copies a trade message ("Hi, I'd like to buy your foo")
- (good) MercuryTrade sends the trade message automatically
- User uses a /command macro (ex: PoE Overlay's /hideout)
- PoE Overlay runs "/hideout" in PoE, (changing the clipboard) then
  returns the clipboard to the old state (changing the clipboard again)
  - The clipboard is again ("Hi, I'd like to buy your foo")
- (bad) Mercury Trade resends the trade message again

And two minor problems:
1) When MT starts or restarts, if your clipboard contains an old trade
  message, MT will resend it.
2) When the user refreshes their item search page, they may lose track
   of which items they have already messaged. In this case, if they have
   already messaged for an item, MT will ping the seller again.

The simple solution to these issues is to check MT's history before
sending a duplicate whisper.

== Why 5?
This seems like a good tradeoff between solving the issues above
(usually only the most recent item is affected) vs creating a new
problem:
- A user may refresh an search, hoping to buy from
  previously-unresponsive sellers. In this case, they expect MT to send
  their whispers, but if MT looks too far back in history (ex: if it
  looks at all history), the user will be confused why the whisper-send
  feature is "broken"

A history of 5 was also chosen by another project's similar feature, [1]
so it seems doubly-reasonable as an initial choice.

(Previous PR had a mismatched history count)