### PR TITLE
Remove android and swt as transitive dependencies

### DIFF
--- a/app-ui/pom.xml
+++ b/app-ui/pom.xml
@@ -55,6 +55,21 @@
         <dependency>
             <groupId>org.pushingpixels</groupId>
             <artifactId>trident</artifactId>
+            <exclusions>
+                <!-- Remove bloat that we don't use. -->
+                <exclusion>
+                    <groupId>com.google.android</groupId>
+                    <artifactId>android</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.swt.gtk.linux</groupId>
+                    <artifactId>x86</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.swt.gtk.linux</groupId>
+                    <artifactId>x86_64</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.imgscalr</groupId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.pushingpixels</groupId>
-            <artifactId>trident</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.arnabk</groupId>
             <artifactId>pgslookandfeel</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>1.1.2</project.version>
+        <project.version>1.1.3</project.version>
 
         <jnativehook.version>2.0.2</jnativehook.version>
         <devjna.version>4.4.0</devjna.version>


### PR DESCRIPTION
Fixes #66 by removing `Trident` as a dependency from `app`, and excluding its transitive dependencies on `android` and SWT `x86` and `x86_64`.

This project does not use android, nor SWT (the Eclipse Standard Widget Toolkit).

I have compiled and tested the jar, and confirmed it still works without those dependencies.
A few extra dependencies are gone as well, which is every dependency from android.  
![image](https://user-images.githubusercontent.com/7364831/117215864-2b521f00-adff-11eb-90b2-fee41f92751a.png)


The resulting jar is now 27MB instead of 35MB. 

It still includes `Trident` with its BSD license. So that still needs to be adressed.
