### PR TITLE
adjust currency regex to match current messages

### DIFF
--- a/app-core/src/main/java/com/mercury/platform/shared/messageparser/PoeTradeCurrencyParser.java
+++ b/app-core/src/main/java/com/mercury/platform/shared/messageparser/PoeTradeCurrencyParser.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 class PoeTradeCurrencyParser extends BaseRegexParser {
 
-    private static final String poeCurrencyPattern = "^(.*\\s)?(.+): (.+ to buy your (\\d+(\\.\\d+)?)? (.+) for my (\\d+(\\.\\d+)?)? (.+) in(.*?)\\s*(offer)?)$";
+    private static final String poeCurrencyPattern = "^(.*\\s)?(.+): (.+ to buy your (\\d+(\\.\\d+)?)? (.+) for my (\\d+(\\.\\d+)?)? (.+) in(.*?)\\.?\\s*(offer.*)?)$";
 
     public PoeTradeCurrencyParser() {
         super(poeCurrencyPattern);

--- a/app-core/src/main/java/com/mercury/platform/shared/messageparser/PoeTradeCurrencyParser.java
+++ b/app-core/src/main/java/com/mercury/platform/shared/messageparser/PoeTradeCurrencyParser.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 class PoeTradeCurrencyParser extends BaseRegexParser {
 
-    private static final String poeCurrencyPattern = "^(.*\\s)?(.+): (.+ to buy your (\\d+(\\.\\d+)?)? (.+) for my (\\d+(\\.\\d+)?)? (.+) in (.*?)\\.\\s*(.*))$";
+    private static final String poeCurrencyPattern = "^(.*\\s)?(.+): (.+ to buy your (\\d+(\\.\\d+)?)? (.+) for my (\\d+(\\.\\d+)?)? (.+) in(.*?)\\s*(offer)?)$";
 
     public PoeTradeCurrencyParser() {
         super(poeCurrencyPattern);


### PR DESCRIPTION
The original regex assumed messages would come in the form:
Hi, I would like to buy your 430 Chaos Orb for my 2 Divine Orb in Crucible. offer

The 'offer' at the end being optional. However, lately most messages in game come in the form:
Hi, I'd like to buy your 430 Chaos Orb for my 2 Divine Orb in Crucible

The regex would expect a period at the end of a trade offer so it could then search for the 'offer' group. Since new trade messages would not have a period, it would not match the PoeTradeCurrencyParser and instead try to match with PoeTradeItemParser. Leading to ??? appearing in the price window. 

This change explicitely searches for 'offer' in a way that supports both message types.