### PR TITLE
Make the Leave Button on Outgoing Notification Panels use /leave instead of /kick nickName

### DIFF
--- a/app-ui/src/main/java/com/mercury/platform/ui/components/panel/notification/controller/NotificationOutgoingController.java
+++ b/app-ui/src/main/java/com/mercury/platform/ui/components/panel/notification/controller/NotificationOutgoingController.java
@@ -25,7 +25,7 @@ public class NotificationOutgoingController implements OutgoingPanelController {
 
     @Override
     public void performLeave(String nickName) {
-        MercuryStoreCore.chatCommandSubject.onNext("/kick " + nickName);
+        MercuryStoreCore.chatCommandSubject.onNext("/leave");
     }
 
     @Override


### PR DESCRIPTION
This removes the need of changing your character name in the settings every time you log onto a different character. The /leave command was introduced a few leagues ago. I didn't remove the "Your nickname" Option from the settings because I don't know where else this setting is used, but it is not necessary for leave functionality anymore.